### PR TITLE
Install gnupg2 and sudo as they are not included in Debian bullseye base install

### DIFF
--- a/tasks/filesystem-sudoers.yml
+++ b/tasks/filesystem-sudoers.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install sudo
+  apt:
+    name: sudo
+    update_cache: yes
+  when: ansible_distribution == "Debian" or ansible_distribution == "Kali GNU/Linux"
 - name: Set file permissions/ownership for sudoers
   file:
     path: /etc/{{ item }}

--- a/tasks/lynis.yml
+++ b/tasks/lynis.yml
@@ -5,6 +5,10 @@
     apt:
       name: apt-transport-https
       update_cache: yes
+  - name: Install gnupg2
+    apt:
+      name: gnupg2
+      update_cache: yes
   - name: Add Lynis signing key
     apt_key:
       id: 84FAA9983B24AEF24D6C87F1FEBB7D1812576482


### PR DESCRIPTION
Install gnupg2 and sudo as they are not included in Debian bullseye base install.