### PR TITLE
ClamAV: factor rundir into a var, gate freshclam, dedupe daemon-reload

### DIFF
--- a/tasks/clamav.yml
+++ b/tasks/clamav.yml
@@ -116,13 +116,13 @@
         - freshclam
         - clamd
       tags: configuration
-    - name: mkdir /var/run/clamav/
+    - name: mkdir {{ clamav.rundir }}
       ansible.builtin.file:
-        path: /var/run/clamav
+        path: '{{ clamav.rundir }}'
         state: directory
         owner: clamav
         group: clamav
-        mode: '0771'
+        mode: '{{ clamav.rundir_mode }}'
     # https://docs.clamav.net/manual/Usage/Configuration.html#clamdconf
     - name: Configure ClamAV
       ansible.builtin.replace:
@@ -374,8 +374,23 @@
     - clamav
     - debian
   block:
-    - name: Run freshclam
+    # The clamav-daemon.service unit has
+    #   ConditionPathExistsGlob=@DATADIR@/main.{c[vl]d,inc}
+    # so systemd silently skips starting the unit if no signature DB exists.
+    # Bootstrap with a one-shot freshclam only when the DB is missing; after
+    # that the clamav-freshclam systemd service handles ongoing updates.
+    - name: Check whether ClamAV main signature DB exists
+      ansible.builtin.find:
+        paths: "{{ clamav.database }}"
+        patterns:
+          - 'main.cvd'
+          - 'main.cld'
+          - 'main.inc'
+      register: clamav_main_db
+      tags: check
+    - name: Run freshclam to bootstrap signature DB
       ansible.builtin.command: /usr/local/bin/freshclam
+      when: clamav_main_db.matched == 0
       changed_when: true
     # Debian does this another way. It has /etc/systemd/system/clamav-daemon.service.d/extend.conf that contains:
     #
@@ -393,13 +408,12 @@
             group: root
             mode: '0755'
         - name: Create /etc/tmpfiles.d/clamav.conf
-          ansible.builtin.copy:
+          ansible.builtin.template:
+            src: clamav.conf.tmpfiles.j2
             dest: /etc/tmpfiles.d/clamav.conf
             owner: root
             group: root
             mode: '0644'
-            content: |
-              d /run/clamav 0755 clamav clamav -
     - name: Download ClamAV systemd services
       ansible.builtin.get_url:
         url: "https://raw.githubusercontent.com/Cisco-Talos/clamav/refs/heads/main/{{ item }}.in"
@@ -428,16 +442,21 @@
         replace: '{{ item.value }}'
       with_dict:
         "@prefix@": /usr/local
+    # Reload systemd manager configuration once, after the unit files have been
+    # downloaded and configured but before enabling/starting them. Pulled out
+    # of the loop below so it does not fire once per item.
+    - name: Reload systemd manager configuration
+      ansible.builtin.systemd_service:
+        daemon_reload: true
     - name: Enable ClamAV systemd services
       tags: molecule-notest
       ansible.builtin.systemd_service:
         name: '{{ item }}'
         enabled: true
         state: started
-        daemon_reload: true
       with_items:
-        - clamav-freshclam
-        - clamav-daemon
+        - clamav-freshclam.service
+        - clamav-daemon.service
 
 - name: clamav-unofficial-sigs
   become: true

--- a/tasks/clamav.yml
+++ b/tasks/clamav.yml
@@ -185,7 +185,7 @@
           Bytecode: "yes"
           DatabaseMirror: database.clamav.net
           DatabaseOwner: clamav
-          PidFile: /run/clamav/freshclam.pid
+          PidFile: "{{ clamav.rundir }}/freshclam.pid"
           DatabaseDirectory: "{{ clamav['database'] }}"
       tags: configuration
     - name: Copy new ClamAV configurations into place

--- a/tasks/clamav.yml
+++ b/tasks/clamav.yml
@@ -444,8 +444,11 @@
         "@prefix@": /usr/local
     # Reload systemd manager configuration once, after the unit files have been
     # downloaded and configured but before enabling/starting them. Pulled out
-    # of the loop below so it does not fire once per item.
+    # of the loop below so it does not fire once per item. Tagged molecule-notest
+    # to match the Enable task -- Molecule containers do not run systemd and
+    # have no systemctl binary, so this would otherwise fail there.
     - name: Reload systemd manager configuration
+      tags: molecule-notest
       ansible.builtin.systemd_service:
         daemon_reload: true
     - name: Enable ClamAV systemd services

--- a/templates/clamav.conf.tmpfiles.j2
+++ b/templates/clamav.conf.tmpfiles.j2
@@ -1,0 +1,6 @@
+# Created by harden.yml -- do not edit.
+#
+# systemd-tmpfiles entry that recreates ClamAV's runtime directory at boot
+# with the ownership and mode clamd expects for its LocalSocket.
+# See systemd-tmpfiles(8) and tmpfiles.d(5).
+d {{ clamav.rundir }} {{ clamav.rundir_mode }} clamav clamav -

--- a/vars.yml
+++ b/vars.yml
@@ -75,11 +75,12 @@ clamav_location: "{% if (ansible_facts['distribution'] == \"Debian\" or ansible_
 # rundir / rundir_mode are used both for the runtime ansible.builtin.file task
 # and the systemd-tmpfiles.d(5) entry that recreates the directory at boot.
 # Keep them in sync so the dir mode does not flip-flop between playbook runs
-# and reboots. clamd's LocalSocket is created under rundir.
+# and reboots. socket and pid both live under rundir and are derived from it
+# so /run/clamav appears in exactly one place.
 clamav: {
-  'socket': "/run/clamav/clamd.sock",
+  'socket': "{{ clamav.rundir }}/clamd.sock",
   'database': "/var/lib/clamav",
-  'pid': "/run/clamav/clamd.pid",
+  'pid': "{{ clamav.rundir }}/clamd.pid",
   'rundir': "/run/clamav",
   'rundir_mode': "0771"
 }

--- a/vars.yml
+++ b/vars.yml
@@ -72,10 +72,16 @@ chkrootkit_conf_dir: '/etc/chkrootkit'
 cisofy_keyring: /etc/apt/keyrings/cisofy.asc
 hsts_max_age: 600
 clamav_location: "{% if (ansible_facts['distribution'] == \"Debian\" or ansible_facts['distribution'] == \"Kali\" or ansible_facts['distribution'] == \"Ubuntu\") and ansible_facts['architecture'] in [\"x86_64\", \"aarch64\"] %}/usr/local/bin{% else %}/usr/bin{% endif %}"
+# rundir / rundir_mode are used both for the runtime ansible.builtin.file task
+# and the systemd-tmpfiles.d(5) entry that recreates the directory at boot.
+# Keep them in sync so the dir mode does not flip-flop between playbook runs
+# and reboots. clamd's LocalSocket is created under rundir.
 clamav: {
   'socket': "/run/clamav/clamd.sock",
   'database': "/var/lib/clamav",
-  'pid': "/run/clamav/clamd.pid"
+  'pid': "/run/clamav/clamd.pid",
+  'rundir': "/run/clamav",
+  'rundir_mode': "0771"
 }
 logind_conf_location: "{% if ansible_facts['distribution'] == \"Slackware\" %}/etc/elogind/logind.conf{% else %}/etc/systemd/logind.conf{% endif %}"
 alert_email: 'root'


### PR DESCRIPTION
Three small cleanups on top of the recent ClamAV merge (b3c4c3b):

1. Add `clamav.rundir` (`/run/clamav`) and `clamav.rundir_mode` (`0771`) to vars.yml. Use the variables in both the mkdir task and the tmpfiles.d entry. The tmpfiles.d entry becomes a template (clamav.conf.tmpfiles.j2) so the variable can be interpolated. Previously the Ansible task created the directory as 0771 while the tmpfiles.d entry declared 0755, so the mode flip-flopped between playbook runs and reboots. Unified on 0771.

2. Gate the "Run freshclam" task on the absence of the main signature DB (main.{cvd,cld,inc}). The upstream clamav-daemon.service unit has `ConditionPathExistsGlob=@DATADIR@/main.{c[vl]d,inc}` so it silently skips starting if the DB is missing -- which is why a one-shot freshclam is needed on first install. Beyond the first run, the freshclam systemd service handles ongoing updates, so re-fetching the DB on every playbook run wastes bandwidth and hits the CDN.

3. Pull `daemon_reload: true` out of the "Enable ClamAV systemd services" loop. It was firing twice per playbook run (once per item). It now runs once, before the enable loop.